### PR TITLE
feat: Switch to Vec for tape memory, allow custom sized tape

### DIFF
--- a/src/builtin/bf_runtime.rs
+++ b/src/builtin/bf_runtime.rs
@@ -11,15 +11,24 @@ pub struct BrainfuckRuntime {
     pub pointer: usize,
     pub instruction: usize,
     pub instruction_stack: Vec<BFToken>,
-    pub memory: [u8; 30000],
+    pub memory: Vec<u8>,
 }
 
 impl BrainfuckRuntime {
+    /// Constructs a new `BrainfuckRuntime` instance with a default tape length of 30,000 cells.
+    /// Each cell is initialized to 0. This default size is typically sufficient for many Brainfuck programs.
     pub fn new() -> Self {
+        Self::with_memory_size(30_000)
+    }
+
+    /// Constructs a `BrainfuckRuntime` with a specified memory size (tape length).
+    /// Initializes the tape with `size` cells, each set to 0. Allows for the creation of a runtime
+    /// with custom memory size, tailored to the needs of specific Brainfuck programs.
+    pub fn with_memory_size(size: usize) -> Self {
         Self {
             instruction: 0,
             pointer: 0,
-            memory: [0x00; 30000],
+            memory: vec![0x00; size],
             instruction_stack: Vec::new(),
         }
     }
@@ -35,7 +44,7 @@ impl Runner for BrainfuckRuntime {
     fn clean_env(&mut self) -> &mut Self {
         self.instruction = 0;
         self.pointer = 0;
-        self.memory = [0x00; 30000];
+        self.memory = vec![0x00; self.memory.len()];
         self.instruction_stack = Vec::new();
         self
     }


### PR DESCRIPTION
I need more tape when executing a certain bf program.

I benchmarked both the stack array and Vec approaches against each other with a very large bf program using Hyperfine, and the difference was less than the std dev.

Should not be a breaking change.