### PR TITLE
Improve doc comments

### DIFF
--- a/src/builtin/bf_runtime.rs
+++ b/src/builtin/bf_runtime.rs
@@ -15,15 +15,13 @@ pub struct BrainfuckRuntime {
 }
 
 impl BrainfuckRuntime {
-    /// Constructs a new `BrainfuckRuntime` instance with a default tape length of 30,000 cells.
-    /// Each cell is initialized to 0. This default size is typically sufficient for many Brainfuck programs.
+    /// Creates a new Brainfuck runtime with a default 30,000-cell memory.
     pub fn new() -> Self {
         Self::with_memory_size(30_000)
     }
 
-    /// Constructs a `BrainfuckRuntime` with a specified memory size (tape length).
-    /// Initializes the tape with `size` cells, each set to 0. Allows for the creation of a runtime
-    /// with custom memory size, tailored to the needs of specific Brainfuck programs.
+    /// Creates a Brainfuck runtime with a custom memory size.
+    /// * `size` - Number of cells in the runtime memory.
     pub fn with_memory_size(size: usize) -> Self {
         Self {
             instruction: 0,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,8 +7,8 @@
 //! runtime.memory = env.memory;
 //! runtime.run_full_stack().clean_env()
 
-use std::{io::BufRead, io::Write};
 use crate::token::BFToken;
+use std::{io::BufRead, io::Write};
 
 pub trait Operator {
     fn op_ptr_left(&mut self);
@@ -22,9 +22,14 @@ pub trait Operator {
 }
 
 pub trait Runner: Clone + Sized {
+    /// Adds a sequence of tokens (instructions) to the runtime's instruction stack.
     fn add_tokens(&mut self, token_stream: Vec<BFToken>) -> &mut Self;
+    /// Resets the runtime environment to its initial state: instruction and pointer are set to zero,
+    /// memory is cleared (all cells set to 0), and the instruction stack is emptied.
     fn clean_env(&mut self) -> &mut Self;
+    /// Executes the next instruction from the instruction stack.
     fn next_instruction(&mut self, reader: &mut impl BufRead, writer: &mut impl Write)
         -> &mut Self;
+    /// Executes all instructions in the stack until the end is reached.
     fn run_full_stack(&mut self, reader: &mut impl BufRead, writer: &mut impl Write) -> &mut Self;
 }


### PR DESCRIPTION
I am very unhappy with the doc comments I added in my last PR. So this PR seeks to amend that, and also throws in a few extra doc comments for good measure.

Also, once this is in, I'd love to see a 6.0.1 release - I want to use this crate (with the custom memory size changes) as a dependency in a crate I'm working on